### PR TITLE
Downgrade Weasyprint to 60.1

### DIFF
--- a/packages/py3-weasyprint/APKBUILD
+++ b/packages/py3-weasyprint/APKBUILD
@@ -4,7 +4,7 @@
 pkgname=py3-weasyprint
 #_pkgreal is used by apkbuild-pypi to find modules at PyPI
 _pkgreal=weasyprint
-pkgver=60.2
+pkgver=60.1
 pkgrel=0
 pkgdesc="The Awesome Document Factory"
 provides=""
@@ -16,7 +16,7 @@ depends="python3 py3-pydyf py3-cffi py3-html5lib py3-tinycss2 py3-cssselect2 py3
 checkdepends="ghostscript py3-pytest py3-pytest-cov py3-pytest-flake8 py3-pytest-isort py3-pytest-xdist ttf-dejavu"
 makedepends="python3-dev py3-flit-core py3-build py3-installer pango-dev"
 subpackages=""
-source="https://files.pythonhosted.org/packages/a6/b8/c6f092e67d00c2e5d6e6cccd30a6dfa4a047a283a3a0e3bfaa534c60ff8d/weasyprint-60.2.tar.gz"
+source="https://files.pythonhosted.org/packages/05/56/4a6733f43a357b99e6bb5e8c8fdb6d817e993367534e83df694dd2bb1604/weasyprint-60.1.tar.gz"
 builddir="$srcdir/$_pkgreal-$pkgver"
 
 build() {
@@ -32,5 +32,5 @@ package() {
 }
 
 sha512sums="
-1da30b2626911c22a996cf7888edc86a7e3534d552325790c3bb06b29a7bedda8021680f5cac1acd6f0aba0658c64cda02cafa1fcba5f3a76bce6bb5fb229b71  weasyprint-60.2.tar.gz
+7fc05c6c80fc6eb251637b529720794df4b7d5c066ecfb4086cb49b7e1c42a51fcb7b2502a79f9f01f6cc5b83d92d5a48c7386b2db555e7dba6eb64e3151d6ae  weasyprint-60.1.tar.gz
 "


### PR DESCRIPTION
Workaround a bug with SVG images in 60.2